### PR TITLE
Meetup plugin

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -44,12 +44,20 @@
                 command="curl https://downloads.wordpress.org/plugin/easy-wp-smtp.zip -o '${plugindir}easy-wp-smtp.zip'" />
         <unzip file="${plugindir}easy-wp-smtp.zip" todir="${plugindir}" />
 
+        <exec
+                escape="false"
+                passthru="true"
+                checkreturn="true"
+                command="curl https://downloads.wordpress.org/plugin/meetup-widgets.2.2.0.zip -o '${plugindir}meetup-widgets.2.2.0.zip'" />
+        <unzip file="${plugindir}meetup-widgets.2.2.0.zip" todir="${plugindir}" />
+
         <fileset dir="${plugindir}" id="deleteFiles">
             <include name="wp-no-category-base.zip" />
             <include name="disqus-comment-system.zip" />
             <include name="crayon-syntax-highlighter.zip" />
             <include name="event-organiser.latest-stable.zip" />
             <include name="easy-wp-smtp.zip" />
+            <include name="meetup-widgets.2.2.0.zip" />
         </fileset>
 
         <delete>

--- a/functions.php
+++ b/functions.php
@@ -242,6 +242,8 @@ add_filter( 'wp_page_menu_args', 'twentytwelve_page_menu_args' );
  *
  * @since Twenty Twelve 1.0
  */
+/*
+ * Nos nao usamos os widgets padrao. Nao ha motivos para manter eles.
 function twentytwelve_widgets_init() {
 	register_sidebar( array(
 		'name' => __( 'Main Sidebar', 'twentytwelve' ),
@@ -274,6 +276,7 @@ function twentytwelve_widgets_init() {
 	) );
 }
 add_action( 'widgets_init', 'twentytwelve_widgets_init' );
+*/
 
 if ( ! function_exists( 'twentytwelve_content_nav' ) ) :
 /**
@@ -540,3 +543,40 @@ function the_bootstrap_content_nav() {
 	}
 }
 endif;
+
+/**
+ * Widgets da home page
+ * Sao 3 colunas, 3 widgets
+ */
+function phpsp_home_widgets_init() {
+    register_sidebar( array(
+        'name' => __( 'First Column'),
+        'id' => 'home-column-1',
+        'description' => __( 'First columns on home page' ),
+        'before_widget' => '<div class="row-fluid widget %2$s" id="%1$s">',
+        'after_widget' => '</div>',
+        'before_title' => '<h2 class="black-block">',
+        'after_title' => '</h2>',
+    ) );
+
+    register_sidebar( array(
+        'name' => __( 'Second Column'),
+        'id' => 'home-column-2',
+        'description' => __( 'Second columns on home page' ),
+        'before_widget' => '<div class="row-fluid widget %2$s" id="%1$s">',
+        'after_widget' => '</div>',
+        'before_title' => '<h2 class="blue-block">',
+        'after_title' => '</h2>',
+    ) );
+
+    register_sidebar( array(
+        'name' => __( 'Third Column'),
+        'id' => 'home-column-3',
+        'description' => __( 'Third columns on home page' ),
+        'before_widget' => '<div class="row-fluid article-phpsp-home widget %2$s" id="%1$s">',
+        'after_widget' => '</div>',
+        'before_title' => '<h2 class="grey-block">',
+        'after_title' => '</h2>',
+    ) );
+}
+add_action( 'widgets_init', 'phpsp_home_widgets_init' );

--- a/index.php
+++ b/index.php
@@ -45,18 +45,25 @@ get_header(); ?>
 		<?php endif; ?>
 	</section>
 	<section class="content">
-		<div class="row-fluid">	
-			<div class="bl_eventos span4">
+		<div class="row-fluid">
+            <div class="bl_eventos span4">
 			    <h2 class="black-block">Próximos <strong>Eventos</strong></h2>
+            <?php if (is_active_sidebar('home-column-1')) : ?>
+                <?php dynamic_sidebar('home-column-1'); ?>
+            <?php else : ?>
 			    <div class="row-fluid article-phpsp-home">
 					<div class="span12">
 						<p><a href="http://www.meetup.com/php-sp/">No Meetup do PHPSP você encontra os eventos do grupo.</a></p>
 						<p><a href="http://www.meetup.com/php-sp/"><img src="<?php bloginfo('template_url'); ?>/img/phpspMaisMeetup.png" alt="Meetup"></a></p>
 					</div>
 				</div>
-			</div>
-			<div class="bl_artigos span4">
+            <?php endif; ?>
+            </div>
+            <div class="bl_artigos span4">
 				<h2 class="blue-block"><strong>Artigos</strong> da comunidade</h2>
+            <?php if (is_active_sidebar('home-column-2')) : ?>
+                <?php dynamic_sidebar('home-column-2'); ?>
+            <?php else : ?>
 				<?php   wp_reset_query();
 					$args = array( 'category_name' => 'artigos', 'posts_per_page' => 5 );
 					$loop = new WP_Query( $args );
@@ -73,9 +80,13 @@ get_header(); ?>
 					</div>
 				<?php endwhile; ?>
 				<a class="todos_artigos" href="<?php echo get_bloginfo('url'); ?>/index.php/category/artigos/">Ver todos os artigos...</a>
-			</div>
-			<div class="bl_avisos span4">
+            <?php endif; ?>
+            </div>
+            <div class="bl_avisos span4">
 			    <h2 class="grey-block"><strong>Avisos</strong> da comunidade</h2>
+            <?php if (is_active_sidebar('home-column-3')) : ?>
+                <?php dynamic_sidebar('home-column-3'); ?>
+            <?php else : ?>
 			    <?php
 				wp_reset_query();				
 				$loop = new WP_Query( array( 'category_name' => 'Avisos', 'posts_per_page' => 1 ) );
@@ -86,7 +97,8 @@ get_header(); ?>
 				    <strong><a href="<?php the_permalink(); ?>">Saiba mais</a></strong>
 				</div>
 			    </div>
-			</div>
+            <?php endif; ?>
+            </div>
 		</div>
 	</section>
 


### PR DESCRIPTION
O plugin do meetup (https://wordpress.org/plugins/meetup-widgets/) cria um widget para mostrar a lista de eventos, próximo evento, entre outros. Para usar temos que suportar widgets na home do site.
Para isso eu mudei as três colunas da home (já que estava por lá mesmo) para serem widgets no lugar de conteúdos "semi-estáticos". Para evitar que haja problemas enquanto tudo não é configurado, o conteúdo atual é utilizado quando os widgets estão vazios.
A única requisição para usar o plugin é ter uma API Key (https://secure.meetup.com/meetup_api/key/). Para lista de eventos basta informar o ID do grupo (php-sp) e para eventos tem a parte chata de ter que atualizar sempre (ele usar o ID do evento e não o último evento da lista).

Resumo: Esse PR altera as três colunas da home do site para Widgets. Quando não houver conteúdo nos widgets o conteúdo atual é mostrado portanto não há risco de ficar com a home "vazia".