### PR TITLE
Widget lateral nas páginas de Arquivo e Post

### DIFF
--- a/archive.php
+++ b/archive.php
@@ -20,44 +20,52 @@
 get_header(); ?>
 
 	<section id="primary" class="site-content">
-		<div id="content" role="main">
+		<div id="content" role="main" class="row-fluid span12">
+            <div class="span8">
 
-		<?php if ( have_posts() ) : ?>
-			<header class="archive-header">
-				<h1 class="archive-title"><?php
-					if ( is_day() ) :
-						printf( __( 'Daily Archives: %s', 'twentytwelve' ), '<span>' . get_the_date() . '</span>' );
-					elseif ( is_month() ) :
-						printf( __( 'Monthly Archives: %s', 'twentytwelve' ), '<span>' . get_the_date( _x( 'F Y', 'monthly archives date format', 'twentytwelve' ) ) . '</span>' );
-					elseif ( is_year() ) :
-						printf( __( 'Yearly Archives: %s', 'twentytwelve' ), '<span>' . get_the_date( _x( 'Y', 'yearly archives date format', 'twentytwelve' ) ) . '</span>' );
-					else :
-						_e( 'Archives', 'twentytwelve' );
-					endif;
-				?></h1>
-			</header><!-- .archive-header -->
+            <?php if ( have_posts() ) : ?>
+                <header class="archive-header">
+                    <h2 class="archive-title"><?php
+                        if ( is_day() ) :
+                            printf( __( 'Arquivo: %s' ), '<span>' . get_the_date() . '</span>' );
+                        elseif ( is_month() ) :
+                            printf( __( 'Arquivo: %s' ), '<span>' . get_the_date( _x( 'F Y', 'monthly archives date format', 'twentytwelve' ) ) . '</span>' );
+                        elseif ( is_year() ) :
+                            printf( __( 'Arquivo: %s' ), '<span>' . get_the_date( _x( 'Y', 'yearly archives date format', 'twentytwelve' ) ) . '</span>' );
+                        else :
+                            _e( 'Arquivo' );
+                        endif;
+                    ?></h2>
+                </header><!-- .archive-header -->
 
-			<?php
-			/* Start the Loop */
-			while ( have_posts() ) : the_post();
-
-				/* Include the post format-specific template for the content. If you want to
-				 * this in a child theme then include a file called called content-___.php
-				 * (where ___ is the post format) and that will be used instead.
-				 */
-				get_template_part( 'content', get_post_format() );
-
-			endwhile;
-
-			twentytwelve_content_nav( 'nav-below' );
+                <?php
+                /* Start the Loop */
+				while ( have_posts() ) : the_post();
+                    ?>
+                    <article itemtype="http://schema.org/Article" itemscope>
+                        <h3><a href="<?php the_permalink(); ?>" rel="bookmark"><?php the_title(); ?></a></h3>
+                        <time itemprop="dateCreated" datetime="<?php the_time('Y-m-d\TH:i'); ?>"><?php echo ucfirst(strtolower(get_the_time('l, j \d\e F, Y'))); ?></time>
+                        <div class="author">By <span itemprop="author"><?php the_author(); ?> </span></div>
+                        <div class="excerpt"><?php the_excerpt(); ?></div>
+                    </article>
+                <?php
+                endwhile;
 			?>
+                <div class="nav-previous">&nbsp;<?php previous_posts_link( '<< Página Anterior' ); ?></div>
+                <div class="nav-next">&nbsp;<?php next_posts_link( 'Próxima Página >>' ); ?></div>
 
-		<?php else : ?>
-			<?php get_template_part( 'content', 'none' ); ?>
-		<?php endif; ?>
+            <?php else : ?>
+                <?php get_template_part( 'content', 'none' ); ?>
+            <?php endif; ?>
+
+            </div>
+            <div class="span4">
+                <?php if (is_active_sidebar('content-right-column-1')) : ?>
+                    <?php dynamic_sidebar('content-right-column-1'); ?>
+                <?php endif; ?>
+            </div>
 
 		</div><!-- #content -->
 	</section><!-- #primary -->
 
-<?php get_sidebar(); ?>
 <?php get_footer(); ?>

--- a/author.php
+++ b/author.php
@@ -14,58 +14,50 @@
 get_header(); ?>
 
 	<section id="primary" class="site-content">
-		<div id="content" role="main">
-
+		<div id="content" role="main"class="row-fluid span12">
+            <div class="span8">
 		<?php if ( have_posts() ) : ?>
-
-			<?php
-				/* Queue the first post, that way we know
-				 * what author we're dealing with (if that is the case).
-				 *
-				 * We reset this later so we can run the loop
-				 * properly with a call to rewind_posts().
-				 */
-				the_post();
-			?>
-
-			<header class="archive-header">
-				<h1 class="archive-title"><?php printf( __( 'Author Archives: %s', 'twentytwelve' ), '<span class="vcard"><a class="url fn n" href="' . esc_url( get_author_posts_url( get_the_author_meta( "ID" ) ) ) . '" title="' . esc_attr( get_the_author() ) . '" rel="me">' . get_the_author() . '</a></span>' ); ?></h1>
-			</header><!-- .archive-header -->
-
-			<?php
-				/* Since we called the_post() above, we need to
-				 * rewind the loop back to the beginning that way
-				 * we can run the loop properly, in full.
-				 */
-				rewind_posts();
-			?>
-
-			<?php twentytwelve_content_nav( 'nav-above' ); ?>
-
 			<?php
 			// If a user has filled out their description, show a bio on their entries.
 			if ( get_the_author_meta( 'description' ) ) : ?>
 			<div class="author-info">
-				<div class="author-avatar">
-					<?php echo get_avatar( get_the_author_meta( 'user_email' ), apply_filters( 'twentytwelve_author_bio_avatar_size', 60 ) ); ?>
-				</div><!-- .author-avatar -->
 				<div class="author-description">
-					<h2><?php printf( __( 'About %s', 'twentytwelve' ), get_the_author() ); ?></h2>
+					<h2 class="blue-block"><?php printf( __( 'Sobre <strong>%s</strong>' ), get_the_author() ); ?></h2>
+                    <div class="author-avatar">
+                        <?php echo get_avatar( get_the_author_meta( 'user_email' ), apply_filters( 'twentytwelve_author_bio_avatar_size', 120 ) ); ?>
+                    </div><!-- .author-avatar -->
 					<p><?php the_author_meta( 'description' ); ?></p>
 				</div><!-- .author-description	-->
 			</div><!-- .author-info -->
 			<?php endif; ?>
+            <h2 class="blue-block"><strong>Posts</strong> de <?php the_author(); ?></h2>
 
-			<?php /* Start the Loop */ ?>
-			<?php while ( have_posts() ) : the_post(); ?>
-				<?php get_template_part( 'content', get_post_format() ); ?>
-			<?php endwhile; ?>
+            <?php
+            /* Start the Loop */
+            while ( have_posts() ) : the_post();
+                ?>
+                <article itemtype="http://schema.org/Article" itemscope>
+                    <h3><a href="<?php the_permalink(); ?>" rel="bookmark"><?php the_title(); ?></a></h3>
+                    <time itemprop="dateCreated" datetime="<?php the_time('Y-m-d\TH:i'); ?>"><?php echo ucfirst(strtolower(get_the_time('l, j \d\e F, Y'))); ?></time>
+                    <div class="author">By <span itemprop="author"><?php the_author(); ?> </span></div>
+                    <div class="excerpt"><?php the_excerpt(); ?></div>
+                </article>
+            <?php
+            endwhile;
+            ?>
+            <div class="nav-previous">&nbsp;<?php previous_posts_link( '<< Página Anterior' ); ?></div>
+            <div class="nav-next">&nbsp;<?php next_posts_link( 'Próxima Página >>' ); ?></div>
 
-			<?php twentytwelve_content_nav( 'nav-below' ); ?>
+        <?php else : ?>
+            <?php get_template_part( 'content', 'none' ); ?>
+        <?php endif; ?>
 
-		<?php else : ?>
-			<?php get_template_part( 'content', 'none' ); ?>
-		<?php endif; ?>
+            </div>
+            <div class="span4">
+                <?php if (is_active_sidebar('content-right-column-1')) : ?>
+                    <?php dynamic_sidebar('content-right-column-1'); ?>
+                <?php endif; ?>
+            </div>
 
 		</div><!-- #content -->
 	</section><!-- #primary -->

--- a/category.php
+++ b/category.php
@@ -13,8 +13,8 @@
 get_header(); ?>
 
 	<section class="content cat">
-		<div class="row-fluid">
-			<div class="span8">			
+		<div class="row-fluid span12">
+			<div class="span8">
 				<h2><?php echo single_cat_title( '', false ); ?></h2>
 			<?php
 				while ( have_posts() ) : the_post();
@@ -27,15 +27,17 @@ get_header(); ?>
 					</article>
 			<?php			
 				endwhile; 
-				//the_bootstrap_content_nav();
 			?>
 			<div class="nav-previous">&nbsp;<?php previous_posts_link( '<< Página Anterior' ); ?></div>
 			<div class="nav-next">&nbsp;<?php next_posts_link( 'Próxima Página >>' ); ?></div>
 			
 			</div>
-			<?php get_sidebar(); ?>
+            <div class="span4">
+            <?php if (is_active_sidebar('content-right-column-1')) : ?>
+                <?php dynamic_sidebar('content-right-column-1'); ?>
+            <?php endif; ?>
+            </div>
 		</div>
 	</section>
-
 
 <?php get_footer(); ?>

--- a/functions.php
+++ b/functions.php
@@ -546,6 +546,7 @@ function the_bootstrap_content_nav() {
 }
 endif;
 
+/** HOME **/
 /**
  * Widgets da home page
  * Sao 3 colunas, 3 widgets
@@ -582,6 +583,7 @@ function phpsp_home_widgets_init() {
     ) );
 }
 add_action( 'widgets_init', 'phpsp_home_widgets_init' );
+
 /**
  * Menus (2 linhas) no Cabecalho
  */
@@ -595,3 +597,20 @@ function register_phpsp_menus()
     );
 }
 add_action('init', 'register_phpsp_menus');
+
+/** Conteudo **/
+/**
+ * Widgets da lateral das paginas
+ */
+function phpsp_conteudo_widgets_init() {
+    register_sidebar( array(
+        'name' => __( 'Right Column'),
+        'id' => 'content-right-column-1',
+        'description' => __( 'Right column widget for content pages' ),
+        'before_widget' => '<div class="row-fluid widget %2$s" id="%1$s">',
+        'after_widget' => '</div>',
+        'before_title' => '<h2 class="blue-block">',
+        'after_title' => '</h2>',
+    ) );
+}
+add_action( 'widgets_init', 'phpsp_conteudo_widgets_init' );

--- a/single.php
+++ b/single.php
@@ -11,7 +11,7 @@ the_post();
 ?>
 
 	<section class="content cat sing">
-		<div class="row-fluid">
+		<div class="row-fluid span12">
 			<div class="span8">
 				<article itemtype="http://schema.org/Article" itemscope>					
 					<h2><?php the_title(); ?></h2>						
@@ -34,7 +34,11 @@ the_post();
 				<?php endif; ?>
 				<?php comments_template(); ?>
 			</div>
-			<?php get_sidebar(); ?>
+            <div class="span4">
+                <?php if (is_active_sidebar('content-right-column-1')) : ?>
+                    <?php dynamic_sidebar('content-right-column-1'); ?>
+                <?php endif; ?>
+            </div>
 		</div>
 	</section>
 

--- a/style.css
+++ b/style.css
@@ -115,10 +115,6 @@ nav ul {
 	margin: 30px 0px;
 }
 
-.cat article time{
-	color: #6c6666;
-}
-
 .cat article .author{
 	margin-bottom: 10px;
 }

--- a/tag.php
+++ b/tag.php
@@ -14,35 +14,44 @@
 get_header(); ?>
 
 	<section id="primary" class="site-content">
-		<div id="content" role="main">
+        <div id="content" role="main" class="row-fluid span12">
+            <div class="span8">
 
-		<?php if ( have_posts() ) : ?>
+            <?php if ( have_posts() ) : ?>
 			<header class="archive-header">
-				<h1 class="archive-title"><?php printf( __( 'Tag Archives: %s', 'twentytwelve' ), '<span>' . single_tag_title( '', false ) . '</span>' ); ?></h1>
+				<h1 class="archive-title"><?php printf( __( 'Arquivo: %s', 'twentytwelve' ), '<span>' . single_tag_title( '', false ) . '</span>' ); ?></h1>
 
 			<?php if ( tag_description() ) : // Show an optional tag description ?>
 				<div class="archive-meta"><?php echo tag_description(); ?></div>
 			<?php endif; ?>
 			</header><!-- .archive-header -->
 
-			<?php
-			/* Start the Loop */
-			while ( have_posts() ) : the_post();
+                <?php
+                /* Start the Loop */
+                while ( have_posts() ) : the_post();
+                    ?>
+                    <article itemtype="http://schema.org/Article" itemscope>
+                        <h3><a href="<?php the_permalink(); ?>" rel="bookmark"><?php the_title(); ?></a></h3>
+                        <time itemprop="dateCreated" datetime="<?php the_time('Y-m-d\TH:i'); ?>"><?php echo ucfirst(strtolower(get_the_time('l, j \d\e F, Y'))); ?></time>
+                        <div class="author">By <span itemprop="author"><?php the_author(); ?> </span></div>
+                        <div class="excerpt"><?php the_excerpt(); ?></div>
+                    </article>
+                <?php
+                endwhile;
+                ?>
+                <div class="nav-previous">&nbsp;<?php previous_posts_link( '<< Página Anterior' ); ?></div>
+                <div class="nav-next">&nbsp;<?php next_posts_link( 'Próxima Página >>' ); ?></div>
 
-				/* Include the post format-specific template for the content. If you want to
-				 * this in a child theme then include a file called called content-___.php
-				 * (where ___ is the post format) and that will be used instead.
-				 */
-				get_template_part( 'content', get_post_format() );
+            <?php else : ?>
+                <?php get_template_part( 'content', 'none' ); ?>
+            <?php endif; ?>
 
-			endwhile;
-
-			twentytwelve_content_nav( 'nav-below' );
-			?>
-
-		<?php else : ?>
-			<?php get_template_part( 'content', 'none' ); ?>
-		<?php endif; ?>
+            </div>
+            <div class="span4">
+                <?php if (is_active_sidebar('content-right-column-1')) : ?>
+                    <?php dynamic_sidebar('content-right-column-1'); ?>
+                <?php endif; ?>
+            </div>
 
 		</div><!-- #content -->
 	</section><!-- #primary -->


### PR DESCRIPTION
Adiciona um widget (genérico) que inclui uma barra lateral (na direita) nas páginas de arquivo (por tema, tag, autor e data) para melhor aproveitamento de espaço para resolver https://github.com/PHPSP/hexagon-project/issues/30.

Fiz apenas um widget "genérico", mas se acharem útil posso dividir ele para cada tipo de página (ou apenas entre arquivo e post).

Ao ser aceito esse PR não faz nada, nem quebra nada. Como não há nada na lateral direita do site nessas páginas enquanto nada for adicionado ao widget nada será exibido.