### PR TITLE
Fixes PHPSP/hexagon-project#33; 

### DIFF
--- a/archive-post.php
+++ b/archive-post.php
@@ -12,7 +12,7 @@
         <h2><a href="<?php the_permalink(); ?>" rel="bookmark"><?php the_title(); ?></a></h2>
         <div class="author">
             <p>Por <span itemprop="author"><?php the_author_posts_link(); ?> </span>
-                em <time itemprop="dateCreated" datetime="<?php the_time('Y-m-d\TH:i'); ?>"><?php echo strtolower(get_the_time('j \d\e F \d\e Y')); ?></time></span>
+                em <time itemprop="dateCreated" datetime="<?php the_time('Y-m-d H:i:s'); ?>"><?php the_date(); ?></time></span>
                 <?php if (!is_category()) : ?>
                 em <span itemprop="category"><?php the_category(','); ?></span>
                 <?php endif; ?>

--- a/archive.php
+++ b/archive.php
@@ -29,9 +29,9 @@ get_header(); ?>
                         if ( is_day() ) :
                             echo  get_the_date();
                         elseif ( is_month() ) :
-                            echo get_the_date( _x('F Y', 'monthly archives date format' ));
+                            echo get_the_date('m/Y');
                         elseif ( is_year() ) :
-                            echo get_the_date( _x('Y', 'yearly archives date format'));
+                            echo get_the_date('Y');
                         endif;
                     ?></h1>
                 </header><!-- .archive-header -->

--- a/content-aside.php
+++ b/content-aside.php
@@ -17,7 +17,7 @@
 		</div><!-- .aside -->
 
 		<footer class="entry-meta">
-			<a href="<?php the_permalink(); ?>" title="<?php echo esc_attr( sprintf( __( 'Permalink to %s', 'twentytwelve' ), the_title_attribute( 'echo=0' ) ) ); ?>" rel="bookmark"><?php echo get_the_date(); ?></a>
+			<a href="<?php the_permalink(); ?>" title="<?php echo esc_attr( sprintf( __( 'Permalink to %s', 'twentytwelve' ), the_title_attribute( 'echo=0' ) ) ); ?>" rel="bookmark"><?php the_date(); ?></a>
 			<?php if ( comments_open() ) : ?>
 			<div class="comments-link">
 				<?php comments_popup_link( '<span class="leave-reply">' . __( 'Leave a reply', 'twentytwelve' ) . '</span>', __( '1 Reply', 'twentytwelve' ), __( '% Replies', 'twentytwelve' ) ); ?>

--- a/content-image.php
+++ b/content-image.php
@@ -16,7 +16,7 @@
 		<footer class="entry-meta">
 			<a href="<?php the_permalink(); ?>" title="<?php echo esc_attr( sprintf( __( 'Permalink to %s', 'twentytwelve' ), the_title_attribute( 'echo=0' ) ) ); ?>" rel="bookmark">
 				<h1><?php the_title(); ?></h1>
-				<h2><time class="entry-date" datetime="<?php echo esc_attr( get_the_date( 'c' ) ); ?>"><?php echo get_the_date(); ?></time></h2>
+				<h2><time class="entry-date" datetime="<?php echo esc_attr( get_the_date( 'c' ) ); ?>"><?php the_date(); ?></time></h2>
 			</a>
 			<?php if ( comments_open() ) : ?>
 			<div class="comments-link">

--- a/content-link.php
+++ b/content-link.php
@@ -15,7 +15,7 @@
 		</div><!-- .entry-content -->
 
 		<footer class="entry-meta">
-			<a href="<?php the_permalink(); ?>" title="<?php echo esc_attr( sprintf( __( 'Permalink to %s', 'twentytwelve' ), the_title_attribute( 'echo=0' ) ) ); ?>" rel="bookmark"><?php echo get_the_date(); ?></a>
+			<a href="<?php the_permalink(); ?>" title="<?php echo esc_attr( sprintf( __( 'Permalink to %s', 'twentytwelve' ), the_title_attribute( 'echo=0' ) ) ); ?>" rel="bookmark"><?php the_date(); ?></a>
 			<?php if ( comments_open() ) : ?>
 			<div class="comments-link">
 				<?php comments_popup_link( '<span class="leave-reply">' . __( 'Leave a reply', 'twentytwelve' ) . '</span>', __( '1 Reply', 'twentytwelve' ), __( '% Replies', 'twentytwelve' ) ); ?>

--- a/content-quote.php
+++ b/content-quote.php
@@ -14,7 +14,7 @@
 		</div><!-- .entry-content -->
 
 		<footer class="entry-meta">
-			<a href="<?php the_permalink(); ?>" title="<?php echo esc_attr( sprintf( __( 'Permalink to %s', 'twentytwelve' ), the_title_attribute( 'echo=0' ) ) ); ?>" rel="bookmark"><?php echo get_the_date(); ?></a>
+			<a href="<?php the_permalink(); ?>" title="<?php echo esc_attr( sprintf( __( 'Permalink to %s', 'twentytwelve' ), the_title_attribute( 'echo=0' ) ) ); ?>" rel="bookmark"><?php the_date(); ?></a>
 			<?php if ( comments_open() ) : ?>
 			<div class="comments-link">
 				<?php comments_popup_link( '<span class="leave-reply">' . __( 'Leave a reply', 'twentytwelve' ) . '</span>', __( '1 Reply', 'twentytwelve' ), __( '% Replies', 'twentytwelve' ) ); ?>

--- a/content-status.php
+++ b/content-status.php
@@ -12,7 +12,7 @@
 		<div class="entry-header">
 			<header>
 				<h1><?php the_author(); ?></h1>
-				<h2><a href="<?php the_permalink(); ?>" title="<?php echo esc_attr( sprintf( __( 'Permalink to %s', 'twentytwelve' ), the_title_attribute( 'echo=0' ) ) ); ?>" rel="bookmark"><?php echo get_the_date(); ?></a></h2>
+				<h2><a href="<?php the_permalink(); ?>" title="<?php echo esc_attr( sprintf( __( 'Permalink to %s', 'twentytwelve' ), the_title_attribute( 'echo=0' ) ) ); ?>" rel="bookmark"><?php the_date(); ?></a></h2>
 			</header>
 			<?php echo get_avatar( get_the_author_meta( 'ID' ), apply_filters( 'twentytwelve_status_avatar', '48' ) ); ?>
 		</div><!-- .entry-header -->

--- a/search.php
+++ b/search.php
@@ -18,7 +18,7 @@ get_header(); ?>
 				?>
 						<article itemscope itemtype="http://schema.org/Article">						
 							<h3><a href="<?php the_permalink(); ?>" rel="bookmark"><?php the_title(); ?></a></h3>						
-							<time itemprop="dateCreated" datetime="<?php the_time('Y-m-d\TH:i'); ?>"><?php echo ucfirst(strtolower(get_the_time('l, j \d\e F, Y'))); ?></time>
+							<time itemprop="dateCreated" datetime="<?php the_time('Y-m-d H:i'); ?>"><?php the_date(); ?></time>
 							<div class="author">By <span itemprop="author"><?php the_author(); ?> </span></div>					
 							<div class="excerpt"><?php the_excerpt(); ?></div>
 						</article>

--- a/single.php
+++ b/single.php
@@ -17,7 +17,7 @@ the_post();
 					<h2><?php the_title(); ?></h2>						
 					<div class="author">
                         <p>Por <span itemprop="author"><?php the_author_posts_link(); ?> </span>
-                            em <time itemprop="dateCreated" datetime="<?php the_time('Y-m-d\TH:i'); ?>"><?php echo strtolower(get_the_time('j \d\e F \d\e Y')); ?></time>
+                            em <time itemprop="dateCreated" datetime="<?php the_time('Y-m-d H:i'); ?>"><?php the_date(); ?></time>
                             em <span itemprop="category"><?php the_category(','); ?></span></p>
                     </div>
 					<div class="excerpt"><?php the_content(); ?></div>


### PR DESCRIPTION
Únicas datas hardcoded agora são com timestamp para tags HTML e arquivos para mês e ano que não são contempladas pelas configurações.

Datas oriundas de plugins também podem estar em inglês ainda.