### PR TITLE
Corrige imagem setada por padrão para a desejada no layout.

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -88,7 +88,7 @@ function twentytwelve_setup() {
 	$custom_header_support = array(
 		// The default image to use.
 		// The %s is a placeholder for the theme template directory URI.
-		'default-image' => '%s/images/headers/path.jpg',
+		'default-image' => '%s/img/cropped-banner.jpg',
 		// The height and width of our custom header.
 		'width' => apply_filters( 'twentytwelve_header_image_width', 1098 ),
 		'height' => apply_filters( 'twentytwelve_header_image_height', 198 ),


### PR DESCRIPTION
A imagem padrão é setada na configuração do tema. WP se comporta diferente quando a imagem não foi setada e quando ela foi excluída. Isso que causou problemas nos testes anteriores. Agora a imagem padrão aparece nos dois casos. Quando não há imagem setada (deploy do tema) e quando a imagem é excluída.