### PR TITLE
Aprimora o uso do plugin de meetup (depende do uso do plugin atualizado)

### DIFF
--- a/widgets.php
+++ b/widgets.php
@@ -314,16 +314,28 @@ if (empty($active_widgets['home-column-1'])) {
 
     $hasChange = true;
 
-    //Meetup
-    $active_widgets['home-column-1'][0] = 'vsmeetlistwidget-1';
+    //Meetup highlight
+    $active_widgets['home-column-1'][0] = 'vsmeetnextsinglewidget-1';
 
-    $meetup_widget_content[1] = array(
+    $meetup_widget_content_1[1] = array(
         'title' => 'Próximos Eventos',
         'id' => 'php-sp',
-        'limit' => 10
+        'date_format' => 'd/m/Y @ g:i a'
     );
 
-    update_option('widget_vsmeetlistwidget', $meetup_widget_content);
+    //Meetup lista outros
+    $active_widgets['home-column-1'][1] = 'vsmeetlistwidget-1';
+
+    $meetup_widget_content_2[1] = array(
+        'title' => '',
+        'id' => 'php-sp',
+        'hide_first' => true,
+        'limit' => 5,
+        'date_format' => 'd/m/Y @ g:i a'
+    );
+
+    update_option('widget_vsmeetnextsinglewidget', $meetup_widget_content_1);
+    update_option('widget_vsmeetlistwidget', $meetup_widget_content_2);
 }
 
 //Configura a segunda coluna, se estiver vazia


### PR DESCRIPTION
Usando a versão 2.3.0 do plugin de meetup (https://github.com/jpjoao/Meetup-Widgets/archive/2.3.0.zip) para dar mais destaque para o próximo evento.

Como fica a coluna da esquerda da home do site após atualizar plugin e subir essa PR:
![image](https://cloud.githubusercontent.com/assets/3832326/8412131/abe7499e-1e7f-11e5-9dfa-424b52723628.png)
