### PR TITLE
Fix installer

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -17,9 +17,9 @@
  *
  * For more information on hooks, actions, and filters, see http://codex.wordpress.org/Plugin_API.
  *
- * @package WordPress
+ * @package    WordPress
  * @subpackage Twenty_Twelve
- * @since Twenty Twelve 1.0
+ * @since      Twenty Twelve 1.0
  */
 
 CONST PHPSP_TEMPLATE_VERSION = '1.5.0';
@@ -27,19 +27,20 @@ CONST PHPSP_TEMPLATE_VERSION = '1.5.0';
 /**
  * Sets up the content width value based on the theme's design and stylesheet.
  */
-if ( ! isset( $content_width ) )
+if ( ! isset( $content_width ) ) {
 	$content_width = 625;
+}
 
 /**
  * Sets up theme defaults and registers the various WordPress features that
  * Twenty Twelve supports.
  *
- * @uses load_theme_textdomain() For translation/localization support.
- * @uses add_editor_style() To add a Visual Editor stylesheet.
- * @uses add_theme_support() To add support for post thumbnails, automatic feed links,
- * 	custom background, and post formats.
- * @uses register_nav_menu() To add support for navigation menus.
- * @uses set_post_thumbnail_size() To set a custom post thumbnail size.
+ * @uses  load_theme_textdomain() For translation/localization support.
+ * @uses  add_editor_style() To add a Visual Editor stylesheet.
+ * @uses  add_theme_support() To add support for post thumbnails, automatic feed links,
+ *    custom background, and post formats.
+ * @uses  register_nav_menu() To add support for navigation menus.
+ * @uses  set_post_thumbnail_size() To set a custom post thumbnail size.
  *
  * @since Twenty Twelve 1.0
  */
@@ -62,11 +63,11 @@ function twentytwelve_setup() {
 	// This theme supports a variety of post formats.
 	add_theme_support( 'post-formats', array( 'aside', 'image', 'link', 'quote', 'status' ) );
 
-    /**
+	/**
 	 * This theme uses wp_nav_menu() in one location.
 	 * register_nav_menu( 'primary', __( 'Primary Menu', 'twentytwelve' ) );
-     * Deixar de lado o manu padrao e passar a usar um menu "nosso"
-    */
+	 * Deixar de lado o manu padrao e passar a usar um menu "nosso"
+	 */
 	/*
 	 * This theme supports custom background color and image, and here
 	 * we also set up the default background color.
@@ -78,32 +79,32 @@ function twentytwelve_setup() {
 	// This theme uses a custom image size for featured images, displayed on "standard" posts.
 	add_theme_support( 'post-thumbnails' );
 	set_post_thumbnail_size( 624, 9999 ); // Unlimited height, soft crop
-	
+
 	// This theme allows users to set a custom background.
 	add_theme_support( 'custom-background', array(
 		// Let WordPress know what our default background color is.
 		'default-color' => 'f1f1f1',
 	) );
-	
+
 	// The custom header business starts here.
 
 	$custom_header_support = array(
 		// The default image to use.
 		// The %s is a placeholder for the theme template directory URI.
-		'default-image' => '%s/img/cropped-banner.jpg',
+		'default-image'       => '%s/img/cropped-banner.jpg',
 		// The height and width of our custom header.
-		'width' => apply_filters( 'twentytwelve_header_image_width', 1098 ),
-		'height' => apply_filters( 'twentytwelve_header_image_height', 198 ),
+		'width'               => apply_filters( 'twentytwelve_header_image_width', 1098 ),
+		'height'              => apply_filters( 'twentytwelve_header_image_height', 198 ),
 		// Support flexible heights.
-		'flex-height' => true,
+		'flex-height'         => true,
 		// Don't support text inside the header image.
-		'header-text' => false,
+		'header-text'         => false,
 		// Callback for styling the header preview in the admin.
 		'admin-head-callback' => 'twentytwelve_admin_header_style',
 	);
-	
+
 	add_theme_support( 'custom-header', $custom_header_support );
-	
+
 	if ( ! function_exists( 'get_custom_header' ) ) {
 		// This is all for compatibility with versions of WordPress prior to 3.4.
 		define( 'HEADER_TEXTCOLOR', '' );
@@ -120,6 +121,7 @@ function twentytwelve_setup() {
 	// Larger images will be auto-cropped to fit, smaller ones will be ignored. See header.php.
 	set_post_thumbnail_size( $custom_header_support['width'], $custom_header_support['height'], true );
 }
+
 add_action( 'after_setup_theme', 'twentytwelve_setup' );
 
 /**
@@ -139,13 +141,15 @@ function twentytwelve_scripts_styles() {
 	 * Adds JavaScript to pages with the comment form to support
 	 * sites with threaded comments (when in use).
 	 */
-	if ( is_singular() && comments_open() && get_option( 'thread_comments' ) )
+	if ( is_singular() && comments_open() && get_option( 'thread_comments' ) ) {
 		wp_enqueue_script( 'comment-reply' );
+	}
 
 	/*
 	 * Adds JavaScript for handling the navigation menu hide-and-show behavior.
 	 */
-	wp_enqueue_script( 'twentytwelve-navigation', get_template_directory_uri() . '/js/navigation.js', array(), '1.0', true );
+	wp_enqueue_script( 'twentytwelve-navigation', get_template_directory_uri() . '/js/navigation.js', array(), '1.0',
+		true );
 
 	/*
 	 * Loads our special font CSS file.
@@ -169,19 +173,21 @@ function twentytwelve_scripts_styles() {
 		   this to 'greek', 'cyrillic' or 'vietnamese'. Do not translate into your own language. */
 		$subset = _x( 'no-subset', 'Open Sans font: add new subset (greek, cyrillic, vietnamese)', 'twentytwelve' );
 
-		if ( 'cyrillic' == $subset )
+		if ( 'cyrillic' == $subset ) {
 			$subsets .= ',cyrillic,cyrillic-ext';
-		elseif ( 'greek' == $subset )
+		} elseif ( 'greek' == $subset ) {
 			$subsets .= ',greek,greek-ext';
-		elseif ( 'vietnamese' == $subset )
+		} elseif ( 'vietnamese' == $subset ) {
 			$subsets .= ',vietnamese';
+		}
 
-		$protocol = is_ssl() ? 'https' : 'http';
+		$protocol   = is_ssl() ? 'https' : 'http';
 		$query_args = array(
 			'family' => 'Open+Sans:400italic,700italic,400,700',
 			'subset' => $subsets,
 		);
-		wp_enqueue_style( 'twentytwelve-fonts', add_query_arg( $query_args, "$protocol://fonts.googleapis.com/css" ), array(), null );
+		wp_enqueue_style( 'twentytwelve-fonts', add_query_arg( $query_args, "$protocol://fonts.googleapis.com/css" ),
+			array(), null );
 	}
 
 	/*
@@ -192,9 +198,11 @@ function twentytwelve_scripts_styles() {
 	/*
 	 * Loads the Internet Explorer specific stylesheet.
 	 */
-	wp_enqueue_style( 'twentytwelve-ie', get_template_directory_uri() . '/css/ie.css', array( 'twentytwelve-style' ), '20121010' );
+	wp_enqueue_style( 'twentytwelve-ie', get_template_directory_uri() . '/css/ie.css', array( 'twentytwelve-style' ),
+		'20121010' );
 	$wp_styles->add_data( 'twentytwelve-ie', 'conditional', 'lt IE 9' );
 }
+
 add_action( 'wp_enqueue_scripts', 'twentytwelve_scripts_styles' );
 
 /**
@@ -204,29 +212,34 @@ add_action( 'wp_enqueue_scripts', 'twentytwelve_scripts_styles' );
  * @since Twenty Twelve 1.0
  *
  * @param string $title Default title text for current view.
- * @param string $sep Optional separator.
+ * @param string $sep   Optional separator.
+ *
  * @return string Filtered title.
  */
 function twentytwelve_wp_title( $title, $sep ) {
 	global $paged, $page;
 
-	if ( is_feed() )
+	if ( is_feed() ) {
 		return $title;
+	}
 
 	// Add the site name.
 	$title .= get_bloginfo( 'name' );
 
 	// Add the site description for the home/front page.
 	$site_description = get_bloginfo( 'description', 'display' );
-	if ( $site_description && ( is_home() || is_front_page() ) )
+	if ( $site_description && ( is_home() || is_front_page() ) ) {
 		$title = "$title $sep $site_description";
+	}
 
 	// Add a page number if necessary.
-	if ( $paged >= 2 || $page >= 2 )
+	if ( $paged >= 2 || $page >= 2 ) {
 		$title = "$title $sep " . sprintf( __( 'Page %s', 'twentytwelve' ), max( $paged, $page ) );
+	}
 
 	return $title;
 }
+
 add_filter( 'wp_title', 'twentytwelve_wp_title', 10, 2 );
 
 /**
@@ -235,10 +248,13 @@ add_filter( 'wp_title', 'twentytwelve_wp_title', 10, 2 );
  * @since Twenty Twelve 1.0
  */
 function twentytwelve_page_menu_args( $args ) {
-	if ( ! isset( $args['show_home'] ) )
+	if ( ! isset( $args['show_home'] ) ) {
 		$args['show_home'] = true;
+	}
+
 	return $args;
 }
+
 add_filter( 'wp_page_menu_args', 'twentytwelve_page_menu_args' );
 
 /**
@@ -283,135 +299,159 @@ add_action( 'widgets_init', 'twentytwelve_widgets_init' );
 */
 
 if ( ! function_exists( 'twentytwelve_content_nav' ) ) :
-/**
- * Displays navigation to next/previous pages when applicable.
- *
- * @since Twenty Twelve 1.0
- */
-function twentytwelve_content_nav( $html_id ) {
-	global $wp_query;
+	/**
+	 * Displays navigation to next/previous pages when applicable.
+	 *
+	 * @since Twenty Twelve 1.0
+	 */
+	function twentytwelve_content_nav( $html_id ) {
+		global $wp_query;
 
-	$html_id = esc_attr( $html_id );
+		$html_id = esc_attr( $html_id );
 
-	if ( $wp_query->max_num_pages > 1 ) : ?>
-		<nav id="<?php echo $html_id; ?>" class="navigation" role="navigation">
-			<h3 class="assistive-text"><?php _e( 'Post navigation', 'twentytwelve' ); ?></h3>
-			<div class="nav-previous alignleft"><?php next_posts_link( __( '<span class="meta-nav">&larr;</span> Older posts', 'twentytwelve' ) ); ?></div>
-			<div class="nav-next alignright"><?php previous_posts_link( __( 'Newer posts <span class="meta-nav">&rarr;</span>', 'twentytwelve' ) ); ?></div>
-		</nav><!-- #<?php echo $html_id; ?> .navigation -->
-	<?php endif;
-}
+		if ( $wp_query->max_num_pages > 1 ) : ?>
+			<nav id="<?php echo $html_id; ?>" class="navigation" role="navigation">
+				<h3 class="assistive-text"><?php _e( 'Post navigation', 'twentytwelve' ); ?></h3>
+
+				<div
+					class="nav-previous alignleft"><?php next_posts_link( __( '<span class="meta-nav">&larr;</span> Older posts',
+						'twentytwelve' ) ); ?></div>
+				<div
+					class="nav-next alignright"><?php previous_posts_link( __( 'Newer posts <span class="meta-nav">&rarr;</span>',
+						'twentytwelve' ) ); ?></div>
+			</nav><!-- #<?php echo $html_id; ?> .navigation -->
+		<?php endif;
+	}
 endif;
 
 if ( ! function_exists( 'twentytwelve_comment' ) ) :
-/**
- * Template for comments and pingbacks.
- *
- * To override this walker in a child theme without modifying the comments template
- * simply create your own twentytwelve_comment(), and that function will be used instead.
- *
- * Used as a callback by wp_list_comments() for displaying the comments.
- *
- * @since Twenty Twelve 1.0
- */
-function twentytwelve_comment( $comment, $args, $depth ) {
-	$GLOBALS['comment'] = $comment;
-	switch ( $comment->comment_type ) :
-		case 'pingback' :
-		case 'trackback' :
-		// Display trackbacks differently than normal comments.
-	?>
-	<li <?php comment_class(); ?> id="comment-<?php comment_ID(); ?>">
-		<p><?php _e( 'Pingback:', 'twentytwelve' ); ?> <?php comment_author_link(); ?> <?php edit_comment_link( __( '(Edit)', 'twentytwelve' ), '<span class="edit-link">', '</span>' ); ?></p>
-	<?php
-			break;
-		default :
-		// Proceed with normal comments.
-		global $post;
-	?>
-	<li <?php comment_class(); ?> id="li-comment-<?php comment_ID(); ?>">
-		<article id="comment-<?php comment_ID(); ?>" class="comment">
-			<header class="comment-meta comment-author vcard">
-				<?php
-					echo get_avatar( $comment, 44 );
-					printf( '<cite class="fn">%1$s %2$s</cite>',
-						get_comment_author_link(),
-						// If current post author is also comment author, make it known visually.
-						( $comment->user_id === $post->post_author ) ? '<span> ' . __( 'Post author', 'twentytwelve' ) . '</span>' : ''
-					);
-					printf( '<a href="%1$s"><time datetime="%2$s">%3$s</time></a>',
-						esc_url( get_comment_link( $comment->comment_ID ) ),
-						get_comment_time( 'c' ),
-						/* translators: 1: date, 2: time */
-						sprintf( __( '%1$s at %2$s', 'twentytwelve' ), get_comment_date(), get_comment_time() )
-					);
+	/**
+	 * Template for comments and pingbacks.
+	 *
+	 * To override this walker in a child theme without modifying the comments template
+	 * simply create your own twentytwelve_comment(), and that function will be used instead.
+	 *
+	 * Used as a callback by wp_list_comments() for displaying the comments.
+	 *
+	 * @since Twenty Twelve 1.0
+	 */
+	function twentytwelve_comment( $comment, $args, $depth ) {
+		$GLOBALS['comment'] = $comment;
+		switch ( $comment->comment_type ) :
+			case 'pingback' :
+			case 'trackback' :
+				// Display trackbacks differently than normal comments.
 				?>
-			</header><!-- .comment-meta -->
+				<li <?php comment_class(); ?> id="comment-<?php comment_ID(); ?>">
+				<p><?php _e( 'Pingback:',
+						'twentytwelve' ); ?> <?php comment_author_link(); ?> <?php edit_comment_link( __( '(Edit)',
+						'twentytwelve' ), '<span class="edit-link">', '</span>' ); ?></p>
+				<?php
+				break;
+			default :
+				// Proceed with normal comments.
+				global $post;
+				?>
+			<li <?php comment_class(); ?> id="li-comment-<?php comment_ID(); ?>">
+				<article id="comment-<?php comment_ID(); ?>" class="comment">
+					<header class="comment-meta comment-author vcard">
+						<?php
+						echo get_avatar( $comment, 44 );
+						printf( '<cite class="fn">%1$s %2$s</cite>',
+							get_comment_author_link(),
+							// If current post author is also comment author, make it known visually.
+							( $comment->user_id === $post->post_author ) ?
+								'<span> ' . __( 'Post author', 'twentytwelve' ) . '</span>' : ''
+						);
+						printf( '<a href="%1$s"><time datetime="%2$s">%3$s</time></a>',
+							esc_url( get_comment_link( $comment->comment_ID ) ),
+							get_comment_time( 'c' ),
+							/* translators: 1: date, 2: time */
+							sprintf( __( '%1$s at %2$s', 'twentytwelve' ), get_comment_date(), get_comment_time() )
+						);
+						?>
+					</header>
+					<!-- .comment-meta -->
 
-			<?php if ( '0' == $comment->comment_approved ) : ?>
-				<p class="comment-awaiting-moderation"><?php _e( 'Your comment is awaiting moderation.', 'twentytwelve' ); ?></p>
-			<?php endif; ?>
+					<?php if ( '0' == $comment->comment_approved ) : ?>
+						<p class="comment-awaiting-moderation"><?php _e( 'Your comment is awaiting moderation.',
+								'twentytwelve' ); ?></p>
+					<?php endif; ?>
 
-			<section class="comment-content comment">
-				<?php comment_text(); ?>
-				<?php edit_comment_link( __( 'Edit', 'twentytwelve' ), '<p class="edit-link">', '</p>' ); ?>
-			</section><!-- .comment-content -->
+					<section class="comment-content comment">
+						<?php comment_text(); ?>
+						<?php edit_comment_link( __( 'Edit', 'twentytwelve' ), '<p class="edit-link">', '</p>' ); ?>
+					</section>
+					<!-- .comment-content -->
 
-			<div class="reply">
-				<?php comment_reply_link( array_merge( $args, array( 'reply_text' => __( 'Reply', 'twentytwelve' ), 'after' => ' <span>&darr;</span>', 'depth' => $depth, 'max_depth' => $args['max_depth'] ) ) ); ?>
-			</div><!-- .reply -->
-		</article><!-- #comment-## -->
-	<?php
-		break;
-	endswitch; // end comment_type check
-}
+					<div class="reply">
+						<?php comment_reply_link( array_merge( $args, array(
+							'reply_text' => __( 'Reply', 'twentytwelve' ),
+							'after'      => ' <span>&darr;</span>',
+							'depth'      => $depth,
+							'max_depth'  => $args['max_depth']
+						) ) ); ?>
+					</div>
+					<!-- .reply -->
+				</article>
+				<!-- #comment-## -->
+				<?php
+				break;
+		endswitch; // end comment_type check
+	}
 endif;
 
 if ( ! function_exists( 'twentytwelve_entry_meta' ) ) :
-/**
- * Prints HTML with meta information for current post: categories, tags, permalink, author, and date.
- *
- * Create your own twentytwelve_entry_meta() to override in a child theme.
- *
- * @since Twenty Twelve 1.0
- */
-function twentytwelve_entry_meta() {
-	// Translators: used between list items, there is a space after the comma.
-	$categories_list = get_the_category_list( __( ', ', 'twentytwelve' ) );
+	/**
+	 * Prints HTML with meta information for current post: categories, tags, permalink, author, and date.
+	 *
+	 * Create your own twentytwelve_entry_meta() to override in a child theme.
+	 *
+	 * @since Twenty Twelve 1.0
+	 */
+	function twentytwelve_entry_meta() {
+		// Translators: used between list items, there is a space after the comma.
+		$categories_list = get_the_category_list( __( ', ', 'twentytwelve' ) );
 
-	// Translators: used between list items, there is a space after the comma.
-	$tag_list = get_the_tag_list( '', __( ', ', 'twentytwelve' ) );
+		// Translators: used between list items, there is a space after the comma.
+		$tag_list = get_the_tag_list( '', __( ', ', 'twentytwelve' ) );
 
-	$date = sprintf( '<a href="%1$s" title="%2$s" rel="bookmark"><time class="entry-date" datetime="%3$s">%4$s</time></a>',
-		esc_url( get_permalink() ),
-		esc_attr( get_the_time() ),
-		esc_attr( get_the_date( 'c' ) ),
-		esc_html( get_the_date() )
-	);
+		$date
+			= sprintf( '<a href="%1$s" title="%2$s" rel="bookmark"><time class="entry-date" datetime="%3$s">%4$s</time></a>',
+			esc_url( get_permalink() ),
+			esc_attr( get_the_time() ),
+			esc_attr( get_the_date( 'c' ) ),
+			esc_html( get_the_date() )
+		);
 
-	$author = sprintf( '<span class="author vcard"><a class="url fn n" href="%1$s" title="%2$s" rel="author">%3$s</a></span>',
-		esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ),
-		esc_attr( sprintf( __( 'View all posts by %s', 'twentytwelve' ), get_the_author() ) ),
-		get_the_author()
-	);
-
-	// Translators: 1 is category, 2 is tag, 3 is the date and 4 is the author's name.
-	if ( $tag_list ) {
-		$utility_text = __( 'This entry was posted in %1$s and tagged %2$s on %3$s<span class="by-author"> by %4$s</span>.', 'twentytwelve' );
-	} elseif ( $categories_list ) {
-		$utility_text = __( 'This entry was posted in %1$s on %3$s<span class="by-author"> by %4$s</span>.', 'twentytwelve' );
-	} else {
-		$utility_text = __( 'This entry was posted on %3$s<span class="by-author"> by %4$s</span>.', 'twentytwelve' );
-	}
-
-	printf(
-		$utility_text,
-		$categories_list,
-		$tag_list,
-		$date,
 		$author
-	);
-}
+			= sprintf( '<span class="author vcard"><a class="url fn n" href="%1$s" title="%2$s" rel="author">%3$s</a></span>',
+			esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ),
+			esc_attr( sprintf( __( 'View all posts by %s', 'twentytwelve' ), get_the_author() ) ),
+			get_the_author()
+		);
+
+		// Translators: 1 is category, 2 is tag, 3 is the date and 4 is the author's name.
+		if ( $tag_list ) {
+			$utility_text
+				= __( 'This entry was posted in %1$s and tagged %2$s on %3$s<span class="by-author"> by %4$s</span>.',
+				'twentytwelve' );
+		} elseif ( $categories_list ) {
+			$utility_text = __( 'This entry was posted in %1$s on %3$s<span class="by-author"> by %4$s</span>.',
+				'twentytwelve' );
+		} else {
+			$utility_text = __( 'This entry was posted on %3$s<span class="by-author"> by %4$s</span>.',
+				'twentytwelve' );
+		}
+
+		printf(
+			$utility_text,
+			$categories_list,
+			$tag_list,
+			$date,
+			$author
+		);
+	}
 endif;
 
 /**
@@ -427,36 +467,44 @@ endif;
  * @since Twenty Twelve 1.0
  *
  * @param array Existing class values.
+ *
  * @return array Filtered class values.
  */
 function twentytwelve_body_class( $classes ) {
 	$background_color = get_background_color();
 
-	if ( ! is_active_sidebar( 'sidebar-1' ) || is_page_template( 'page-templates/full-width.php' ) )
+	if ( ! is_active_sidebar( 'sidebar-1' ) || is_page_template( 'page-templates/full-width.php' ) ) {
 		$classes[] = 'full-width';
+	}
 
 	if ( is_page_template( 'page-templates/front-page.php' ) ) {
 		$classes[] = 'template-front-page';
-		if ( has_post_thumbnail() )
+		if ( has_post_thumbnail() ) {
 			$classes[] = 'has-post-thumbnail';
-		if ( is_active_sidebar( 'sidebar-2' ) && is_active_sidebar( 'sidebar-3' ) )
+		}
+		if ( is_active_sidebar( 'sidebar-2' ) && is_active_sidebar( 'sidebar-3' ) ) {
 			$classes[] = 'two-sidebars';
+		}
 	}
 
-	if ( empty( $background_color ) )
+	if ( empty( $background_color ) ) {
 		$classes[] = 'custom-background-empty';
-	elseif ( in_array( $background_color, array( 'fff', 'ffffff' ) ) )
+	} elseif ( in_array( $background_color, array( 'fff', 'ffffff' ) ) ) {
 		$classes[] = 'custom-background-white';
+	}
 
 	// Enable custom font class only if the font CSS is queued to load.
-	if ( wp_style_is( 'twentytwelve-fonts', 'queue' ) )
+	if ( wp_style_is( 'twentytwelve-fonts', 'queue' ) ) {
 		$classes[] = 'custom-font-enabled';
+	}
 
-	if ( ! is_multi_author() )
+	if ( ! is_multi_author() ) {
 		$classes[] = 'single-author';
+	}
 
 	return $classes;
 }
+
 add_filter( 'body_class', 'twentytwelve_body_class' );
 
 /**
@@ -466,11 +514,14 @@ add_filter( 'body_class', 'twentytwelve_body_class' );
  * @since Twenty Twelve 1.0
  */
 function twentytwelve_content_width() {
-	if ( is_page_template( 'page-templates/full-width.php' ) || is_attachment() || ! is_active_sidebar( 'sidebar-1' ) ) {
+	if ( is_page_template( 'page-templates/full-width.php' ) || is_attachment()
+	     || ! is_active_sidebar( 'sidebar-1' )
+	) {
 		global $content_width;
 		$content_width = 960;
 	}
 }
+
 add_action( 'template_redirect', 'twentytwelve_content_width' );
 
 /**
@@ -479,12 +530,14 @@ add_action( 'template_redirect', 'twentytwelve_content_width' );
  * @since Twenty Twelve 1.0
  *
  * @param WP_Customize_Manager $wp_customize Theme Customizer object.
+ *
  * @return void
  */
 function twentytwelve_customize_register( $wp_customize ) {
-	$wp_customize->get_setting( 'blogname' )->transport = 'postMessage';
+	$wp_customize->get_setting( 'blogname' )->transport        = 'postMessage';
 	$wp_customize->get_setting( 'blogdescription' )->transport = 'postMessage';
 }
+
 add_action( 'customize_register', 'twentytwelve_customize_register' );
 
 /**
@@ -493,59 +546,62 @@ add_action( 'customize_register', 'twentytwelve_customize_register' );
  * @since Twenty Twelve 1.0
  */
 function twentytwelve_customize_preview_js() {
-	wp_enqueue_script( 'twentytwelve-customizer', get_template_directory_uri() . '/js/theme-customizer.js', array( 'customize-preview' ), '20120827', true );
+	wp_enqueue_script( 'twentytwelve-customizer', get_template_directory_uri() . '/js/theme-customizer.js',
+		array( 'customize-preview' ), '20120827', true );
 }
+
 add_action( 'customize_preview_init', 'twentytwelve_customize_preview_js' );
 
 //ini_set( 'mysql.trace_mode', 0 );
 
 if ( ! function_exists( 'the_bootstrap_content_nav' ) ) :
-/**
- * Display navigation to next/previous pages when applicable
- *
- * To be honest - I'm pretty proud of this function. Through a lot of trial and
- * error, I was able to user a core WordPress function (paginate_links()) and
- * adjust it in a way, that the end result is a legitimate pagination.
- * A pagination many developers buy (code) expensively with Plugins like
- * WP Pagenavi. No need! WordPress has it all!
- *
- * @author	Konstantin Obenland
- * @since	1.0.0 - 05.02.2012
- *
- * @return	void
- */
-function the_bootstrap_content_nav() {
-	global $wp_query, $wp_rewrite;
+	/**
+	 * Display navigation to next/previous pages when applicable
+	 *
+	 * To be honest - I'm pretty proud of this function. Through a lot of trial and
+	 * error, I was able to user a core WordPress function (paginate_links()) and
+	 * adjust it in a way, that the end result is a legitimate pagination.
+	 * A pagination many developers buy (code) expensively with Plugins like
+	 * WP Pagenavi. No need! WordPress has it all!
+	 *
+	 * @author    Konstantin Obenland
+	 * @since     1.0.0 - 05.02.2012
+	 *
+	 * @return    void
+	 */
+	function the_bootstrap_content_nav() {
+		global $wp_query, $wp_rewrite;
 
-	$paged			=	( get_query_var( 'paged' ) ) ? intval( get_query_var( 'paged' ) ) : 1;
+		$paged = ( get_query_var( 'paged' ) ) ? intval( get_query_var( 'paged' ) ) : 1;
 
-	$pagenum_link	=	html_entity_decode( get_pagenum_link() );
-	$query_args		=	array();
-	$url_parts		=	explode( '?', $pagenum_link );
-	
-	if ( isset( $url_parts[1] ) ) {
-		wp_parse_str( $url_parts[1], $query_args );
+		$pagenum_link = html_entity_decode( get_pagenum_link() );
+		$query_args   = array();
+		$url_parts    = explode( '?', $pagenum_link );
+
+		if ( isset( $url_parts[1] ) ) {
+			wp_parse_str( $url_parts[1], $query_args );
+		}
+		$pagenum_link = remove_query_arg( array_keys( $query_args ), $pagenum_link );
+		$pagenum_link = trailingslashit( $pagenum_link ) . '%_%';
+
+		$format = ( $wp_rewrite->using_index_permalinks() AND ! strpos( $pagenum_link, 'index.php' ) ) ? 'index.php/'
+			: '';
+		$format .= $wp_rewrite->using_permalinks() ? user_trailingslashit( 'page/%#%', 'paged' ) : '?paged=%#%';
+
+		$links = paginate_links( array(
+			'base'     => $pagenum_link,
+			'format'   => $format,
+			'total'    => $wp_query->max_num_pages,
+			'current'  => $paged,
+			'mid_size' => 3,
+			'type'     => 'list',
+			'add_args' => array_map( 'urlencode', $query_args )
+		) );
+
+		if ( $links ) {
+			echo "<nav class=\"pagination pagination-centered clearfix\">{$links}</nav>";
+		}
 	}
-	$pagenum_link	=	remove_query_arg( array_keys( $query_args ), $pagenum_link );
-	$pagenum_link	=	trailingslashit( $pagenum_link ) . '%_%';
-	
-	$format			=	( $wp_rewrite->using_index_permalinks() AND ! strpos( $pagenum_link, 'index.php' ) ) ? 'index.php/' : '';
-	$format			.=	$wp_rewrite->using_permalinks() ? user_trailingslashit( 'page/%#%', 'paged' ) : '?paged=%#%';
-	
-	$links	=	paginate_links( array(
-		'base'		=>	$pagenum_link,
-		'format'	=>	$format,
-		'total'		=>	$wp_query->max_num_pages,
-		'current'	=>	$paged,
-		'mid_size'	=>	3,
-		'type'		=>	'list',
-		'add_args'	=>	array_map( 'urlencode', $query_args )
-	) );
-
-	if ( $links ) {
-		echo "<nav class=\"pagination pagination-centered clearfix\">{$links}</nav>";
-	}
-}
 endif;
 
 /** HOME **/
@@ -554,88 +610,90 @@ endif;
  * Sao 3 colunas, 3 widgets
  */
 function phpsp_home_widgets_init() {
-    register_sidebar( array(
-        'name' => __( 'First Column'),
-        'id' => 'home-column-1',
-        'description' => __( 'First columns on home page' ),
-        'before_widget' => '<div class="row-fluid widget %2$s" id="%1$s">',
-        'after_widget' => '</div>',
-        'before_title' => '<h2 class="black-block">',
-        'after_title' => '</h2>',
-    ) );
+	register_sidebar( array(
+		'name'          => __( 'First Column' ),
+		'id'            => 'home-column-1',
+		'description'   => __( 'First columns on home page' ),
+		'before_widget' => '<div class="row-fluid widget %2$s" id="%1$s">',
+		'after_widget'  => '</div>',
+		'before_title'  => '<h2 class="black-block">',
+		'after_title'   => '</h2>',
+	) );
 
-    register_sidebar( array(
-        'name' => __( 'Second Column'),
-        'id' => 'home-column-2',
-        'description' => __( 'Second columns on home page' ),
-        'before_widget' => '<div class="row-fluid widget %2$s" id="%1$s">',
-        'after_widget' => '</div>',
-        'before_title' => '<h2 class="blue-block">',
-        'after_title' => '</h2>',
-    ) );
+	register_sidebar( array(
+		'name'          => __( 'Second Column' ),
+		'id'            => 'home-column-2',
+		'description'   => __( 'Second columns on home page' ),
+		'before_widget' => '<div class="row-fluid widget %2$s" id="%1$s">',
+		'after_widget'  => '</div>',
+		'before_title'  => '<h2 class="blue-block">',
+		'after_title'   => '</h2>',
+	) );
 
-    register_sidebar( array(
-        'name' => __( 'Third Column'),
-        'id' => 'home-column-3',
-        'description' => __( 'Third columns on home page' ),
-        'before_widget' => '<div class="row-fluid article-phpsp-home widget %2$s" id="%1$s">',
-        'after_widget' => '</div>',
-        'before_title' => '<h2 class="grey-block">',
-        'after_title' => '</h2>',
-    ) );
+	register_sidebar( array(
+		'name'          => __( 'Third Column' ),
+		'id'            => 'home-column-3',
+		'description'   => __( 'Third columns on home page' ),
+		'before_widget' => '<div class="row-fluid article-phpsp-home widget %2$s" id="%1$s">',
+		'after_widget'  => '</div>',
+		'before_title'  => '<h2 class="grey-block">',
+		'after_title'   => '</h2>',
+	) );
 
-    register_sidebar( array(
-        'name' => __( 'Website Header'),
-        'id' => 'head-announce',
-        'description' => __( 'Website Header' ),
-        'before_widget' => '<section class="container">',
-        'after_widget' => '</section>',
-        'before_title' => '',
-        'after_title' => '',
-    ) );
+	register_sidebar( array(
+		'name'          => __( 'Website Header' ),
+		'id'            => 'head-announce',
+		'description'   => __( 'Website Header' ),
+		'before_widget' => '<section class="container">',
+		'after_widget'  => '</section>',
+		'before_title'  => '',
+		'after_title'   => '',
+	) );
 
-    register_sidebar( array(
-        'name' => __( 'Website Footer Links'),
-        'id' => 'footer-links',
-        'description' => __( 'Website Footer Links' ),
-        'before_widget' => '',
-        'after_widget' => '',
-        'before_title' => '<h3>',
-        'after_title' => '</h3>',
-    ) );
+	register_sidebar( array(
+		'name'          => __( 'Website Footer Links' ),
+		'id'            => 'footer-links',
+		'description'   => __( 'Website Footer Links' ),
+		'before_widget' => '',
+		'after_widget'  => '',
+		'before_title'  => '<h3>',
+		'after_title'   => '</h3>',
+	) );
 }
+
 add_action( 'widgets_init', 'phpsp_home_widgets_init' );
 
 /**
  * Menus (2 linhas) no Cabecalho
  *
  */
-function register_phpsp_menus()
-{
-    register_nav_menus(
-        array(
-            'header-menu-1' => __('Header Menu Line 1'),
-            'header-menu-2' => __('Header Menu Line 2')
-        )
-    );
+function register_phpsp_menus() {
+	register_nav_menus(
+		array(
+			'header-menu-1' => __( 'Header Menu Line 1' ),
+			'header-menu-2' => __( 'Header Menu Line 2' )
+		)
+	);
 }
-add_action('init', 'register_phpsp_menus');
+
+add_action( 'init', 'register_phpsp_menus' );
 
 /** Conteudo **/
 /**
  * Widgets da lateral das paginas
  */
 function phpsp_conteudo_widgets_init() {
-    register_sidebar( array(
-        'name' => __( 'Right Column'),
-        'id' => 'content-right-column-1',
-        'description' => __( 'Right column widget for content pages' ),
-        'before_widget' => '<div class="row-fluid widget %2$s" id="%1$s">',
-        'after_widget' => '</div>',
-        'before_title' => '<h2 class="blue-block">',
-        'after_title' => '</h2>',
-    ) );
+	register_sidebar( array(
+		'name'          => __( 'Right Column' ),
+		'id'            => 'content-right-column-1',
+		'description'   => __( 'Right column widget for content pages' ),
+		'before_widget' => '<div class="row-fluid widget %2$s" id="%1$s">',
+		'after_widget'  => '</div>',
+		'before_title'  => '<h2 class="blue-block">',
+		'after_title'   => '</h2>',
+	) );
 }
+
 add_action( 'widgets_init', 'phpsp_conteudo_widgets_init' );
 
 /**
@@ -646,14 +704,14 @@ add_action( 'widgets_init', 'phpsp_conteudo_widgets_init' );
  * @return bool
  */
 function phpsp_busca_menu( $args ) {
-    if (isset($args['menu']) && !empty($args['menu'])) {
-        return false;
-    } else {
-        $args['menu'] = $args['theme_location'];
-        unset($args['theme_location']);
-        wp_nav_menu($args);
-    }
+	if ( isset( $args['menu'] ) && ! empty( $args['menu'] ) ) {
+		return false;
+	} else {
+		$args['menu'] = $args['theme_location'];
+		unset( $args['theme_location'] );
+		wp_nav_menu( $args );
+	}
 }
 
 /** add widgets */
-require_once(TEMPLATEPATH."/widgets.php");
+require_once( TEMPLATEPATH . "/widgets.php" );

--- a/functions.php
+++ b/functions.php
@@ -22,6 +22,8 @@
  * @since Twenty Twelve 1.0
  */
 
+CONST PHPSP_TEMPLATE_VERSION = '1.5.0';
+
 /**
  * Sets up the content width value based on the theme's design and stylesheet.
  */

--- a/functions.php
+++ b/functions.php
@@ -22,8 +22,6 @@
  * @since      Twenty Twelve 1.0
  */
 
-CONST PHPSP_TEMPLATE_VERSION = '1.5.0';
-
 /**
  * Sets up the content width value based on the theme's design and stylesheet.
  */

--- a/widgets.php
+++ b/widgets.php
@@ -1,4 +1,9 @@
 <?php
+/** Configuration */
+if (!get_option('phpsp_data_version'))
+{
+    add_option('phpsp_data_version', '0');
+}
 
 /** Widgets classes */
 class PHPSP_Artigos_Widget extends WP_Widget {
@@ -321,6 +326,18 @@ $active_widgets = get_option( 'sidebars_widgets' );
 //Pra nao salvar atoa
 $hasChange = false;
 
+$dataVersion = get_option('phpsp_data_version');
+
+$forceUdate = version_compare(PHPSP_TEMPLATE_VERSION, $dataVersion, '>') ? true : false;
+
+if($forceUdate)
+{
+    $hasChange = true;
+    $active_widgets = array('array_version' => 1);
+    $active_widgets['orphaned_widgets_1'] = array();
+    $active_widgets['wp_inactive_widgets'] = array();
+}
+
 //Configura a primeira coluna, se estiver vazia
 if (empty($active_widgets['home-column-1'])) {
 
@@ -405,14 +422,47 @@ if (empty($active_widgets['footer-links'])) {
         'title' => 'PHPSP nas redes sociais',
     );
 
-    $active_widgets['footer-links'][2] = 'phpsp-parceiros-1';
+    $active_widgets['footer-links'][1] = 'phpsp-parceiros-1';
 
-    $footer_partners_widget_content[3] = array();
+    $footer_partners_widget_content[1] = array();
 
     update_option('widget_phpsp-social', $footer_social_widget_content);
     update_option('widget_phpsp-parceiros', $footer_partners_widget_content);
 }
 
+//Configura a lateral direita (paginas internas)
+if (empty($active_widgets['content-right-column-1'])) {
+
+    $hasChange = true;
+
+    //Outros artigos
+    $active_widgets['content-right-column-1'][0] = 'phpsp-artigos-2';
+
+    $artigos_widget_content[2] = array(
+        'title' => 'Últimos Artigos',
+        'cat' => 3,
+        'limit' => 5,
+        'more' => 'Ver mais artigos...'
+    );
+
+    $active_widgets['content-right-column-1'][1] = 'categories-1';
+
+    $footer_categories_widget_content[1] = array(
+        'title' => 'Outros Temas',
+        'count' => 1,
+        'hierarchial' => 1,
+    );
+
+    update_option('widget_phpsp-artigos', $artigos_widget_content);
+    update_option('widget_categories', $footer_categories_widget_content);
+}
+
 if ($hasChange) {
+
     update_option( 'sidebars_widgets', $active_widgets );
+
+    if($forceUdate)
+    {
+        update_option('phpsp_data_version', PHPSP_TEMPLATE_VERSION);
+    }
 }

--- a/widgets.php
+++ b/widgets.php
@@ -352,7 +352,9 @@ $hasChange = false;
 
 $dataVersion = get_option( 'phpsp_data_version' );
 
-$forceUdate = version_compare( PHPSP_TEMPLATE_VERSION, $dataVersion, '>' ) ? true : false;
+$themeVersion = wp_get_theme()->get( 'Version' );
+
+$forceUdate = version_compare( $themeVersion, $dataVersion, '>' ) ? true : false;
 
 if ( $forceUdate ) {
 	$hasChange                             = true;
@@ -485,6 +487,6 @@ if ( $hasChange ) {
 	update_option( 'sidebars_widgets', $active_widgets );
 
 	if ( $forceUdate ) {
-		update_option( 'phpsp_data_version', PHPSP_TEMPLATE_VERSION );
+		update_option( 'phpsp_data_version', $themeVersion );
 	}
 }

--- a/widgets.php
+++ b/widgets.php
@@ -1,243 +1,265 @@
 <?php
 /** Configuration */
-if (!get_option('phpsp_data_version'))
-{
-    add_option('phpsp_data_version', '0');
+if ( ! get_option( 'phpsp_data_version' ) ) {
+	add_option( 'phpsp_data_version', '0' );
 }
 
 /** Widgets classes */
 class PHPSP_Artigos_Widget extends WP_Widget {
 
-    public function PHPSP_Artigos_Widget() {
-        parent::WP_Widget('phpsp-artigos', 'PHPSP - Artigos', ' Lista de Artigos de uma categoria');
-    }
+	public function PHPSP_Artigos_Widget() {
+		parent::WP_Widget( 'phpsp-artigos', 'PHPSP - Artigos', ' Lista de Artigos de uma categoria' );
+	}
 
-    public function widget ($args, $instance) {
-        $query_args = array( 'cat' => $instance['cat'], 'posts_per_page' => $instance['limit'] );
-        $loop = new WP_Query($query_args);
-        echo $args['before_widget'];
-        echo $args['before_title'] . $instance['title'] . $args['after_title'];
+	public function widget( $args, $instance ) {
+		$query_args = array( 'cat' => $instance['cat'], 'posts_per_page' => $instance['limit'] );
+		$loop       = new WP_Query( $query_args );
+		echo $args['before_widget'];
+		echo $args['before_title'] . $instance['title'] . $args['after_title'];
 
-        while ($loop->have_posts()) {
-            $loop->the_post();
-            get_template_part('widget', 'artigos');
-        }
+		while ( $loop->have_posts() ) {
+			$loop->the_post();
+			get_template_part( 'widget', 'artigos' );
+		}
 
-        echo '<div class="todos_artigos"><a href="' . get_category_link($instance['cat']) . '">' . $instance['more'] . '</a></div>';
+		echo '<div class="todos_artigos"><a href="' . get_category_link( $instance['cat'] ) . '">' . $instance['more']
+		     . '</a></div>';
 
-        echo $args['after_widget'];
-    }
+		echo $args['after_widget'];
+	}
 
-    public function update($new_instance, $old_instance) {
-        $instance = $old_instance;
-        $instance['title'] = strip_tags($new_instance['title'], '<strong></strong>');
-        $instance['cat'] = strip_tags($new_instance['cat']);
-        $instance['limit'] = strip_tags($new_instance['limit']);
-        $instance['more'] = strip_tags($new_instance['more']);
+	public function update( $new_instance, $old_instance ) {
+		$instance          = $old_instance;
+		$instance['title'] = strip_tags( $new_instance['title'], '<strong></strong>' );
+		$instance['cat']   = strip_tags( $new_instance['cat'] );
+		$instance['limit'] = strip_tags( $new_instance['limit'] );
+		$instance['more']  = strip_tags( $new_instance['more'] );
 
-        return $instance;
-    }
+		return $instance;
+	}
 
-    public function form($instance) {
-        if ( $instance ) {
-            $title = esc_attr($instance['title']);
-            $cat = esc_attr($instance['cat']);
-            $limit = esc_attr($instance['limit']);
-            $more = esc_attr($instance['more']);
-        } else {
-            $title = '';
-            $cat = '';
-            $limit = 5;
-            $more = ' Ver mais...';
-        }
+	public function form( $instance ) {
+		if ( $instance ) {
+			$title = esc_attr( $instance['title'] );
+			$cat   = esc_attr( $instance['cat'] );
+			$limit = esc_attr( $instance['limit'] );
+			$more  = esc_attr( $instance['more'] );
+		} else {
+			$title = '';
+			$cat   = '';
+			$limit = 5;
+			$more  = ' Ver mais...';
+		}
 
-        $form = '
+		$form
+			= '
         <p>
-            <label for="' . $this->get_field_id('title') . '">
+            <label for="' . $this->get_field_id( 'title' ) . '">
                 Título
-                <input class="widefat" id="' . $this->get_field_id('title') . '" name="' . $this->get_field_name('title') . '" type="text" value="' . $title . '" />
+                <input class="widefat" id="' . $this->get_field_id( 'title' ) . '" name="'
+			  . $this->get_field_name( 'title' ) . '" type="text" value="' . $title . '" />
             </label>
         </p>
         <p>
-            <label for="' . $this->get_field_id('cat') . '">
+            <label for="' . $this->get_field_id( 'cat' ) . '">
                 Categoria
-                <select id="' . $this->get_field_id('cat') . '" name="' . $this->get_field_name('cat') . '" class="widefat" style="width:100%;">';
+                <select id="' . $this->get_field_id( 'cat' ) . '" name="' . $this->get_field_name( 'cat' )
+			  . '" class="widefat" style="width:100%;">';
 
-        foreach(get_terms('category','parent=0&hide_empty=0') as $term) {
-            $form .= '<option ' . selected($cat, $term->term_id, false ) . ' value="' . $term->term_id . '">' . $term->name . '</option>';
-        }
+		foreach ( get_terms( 'category', 'parent=0&hide_empty=0' ) as $term ) {
+			$form
+				.=
+				'<option ' . selected( $cat, $term->term_id, false ) . ' value="' . $term->term_id . '">' . $term->name
+				. '</option>';
+		}
 
-        $form .= '
+		$form
+			.= '
                 </select>
             </label>
         </p>
         <p>
-            <label for="' . $this->get_field_id('limit') . '">
+            <label for="' . $this->get_field_id( 'limit' ) . '">
                 Quantidade
-                <input class="widefat" id="' . $this->get_field_id('limit') . '" name="' . $this->get_field_name('limit') . '" type="text" value="' . $limit . '" />
+                <input class="widefat" id="' . $this->get_field_id( 'limit' ) . '" name="'
+			   . $this->get_field_name( 'limit' ) . '" type="text" value="' . $limit . '" />
             </label>
         </p>
         <p>
-            <label for="' . $this->get_field_id('more') . '">
+            <label for="' . $this->get_field_id( 'more' ) . '">
                 Texto final
-                <input class="widefat" id="' . $this->get_field_id('more') . '" name="' . $this->get_field_name('more') . '" type="text" value="' . $more . '" />
+                <input class="widefat" id="' . $this->get_field_id( 'more' ) . '" name="'
+			   . $this->get_field_name( 'more' ) . '" type="text" value="' . $more . '" />
             </label>
         </p>
         ';
 
-        echo $form;
-    }
+		echo $form;
+	}
 }
 
 class PHPSP_Avisos_Widget extends WP_Widget {
 
-    public function PHPSP_Avisos_Widget() {
-        parent::WP_Widget('phpsp-avisos', 'PHPSP - Avisos', ' Lista de Avisos de uma categoria');
-    }
+	public function PHPSP_Avisos_Widget() {
+		parent::WP_Widget( 'phpsp-avisos', 'PHPSP - Avisos', ' Lista de Avisos de uma categoria' );
+	}
 
-    public function widget ($args, $instance) {
-        $query_args = array( 'cat' => $instance['cat'], 'posts_per_page' => $instance['limit'] );
-        $loop = new WP_Query($query_args);
-        echo $args['before_widget'];
-        echo $args['before_title'] . $instance['title'] . $args['after_title'];
+	public function widget( $args, $instance ) {
+		$query_args = array( 'cat' => $instance['cat'], 'posts_per_page' => $instance['limit'] );
+		$loop       = new WP_Query( $query_args );
+		echo $args['before_widget'];
+		echo $args['before_title'] . $instance['title'] . $args['after_title'];
 
-        while ($loop->have_posts()) {
-            $loop->the_post();
-            get_template_part('widget', 'avisos');
-        }
+		while ( $loop->have_posts() ) {
+			$loop->the_post();
+			get_template_part( 'widget', 'avisos' );
+		}
 
-        if ($instance['show_more']) {
-            echo '<div class="todos_artigos"><a href="' . get_category_link($instance['cat']) . '">' . $instance['more'] . '</a></div>';
-        }
+		if ( $instance['show_more'] ) {
+			echo '<div class="todos_artigos"><a href="' . get_category_link( $instance['cat'] ) . '">'
+			     . $instance['more'] . '</a></div>';
+		}
 
-        echo $args['after_widget'];
-    }
+		echo $args['after_widget'];
+	}
 
-    public function update($new_instance, $old_instance) {
-        $instance = $old_instance;
-        $instance['title'] = strip_tags($new_instance['title'], '<strong></strong>');
-        $instance['cat'] = strip_tags($new_instance['cat']);
-        $instance['limit'] = strip_tags($new_instance['limit']);
-        $instance['show_more'] = strip_tags($new_instance['show_more']);
-        $instance['more'] = strip_tags($new_instance['more']);
+	public function update( $new_instance, $old_instance ) {
+		$instance              = $old_instance;
+		$instance['title']     = strip_tags( $new_instance['title'], '<strong></strong>' );
+		$instance['cat']       = strip_tags( $new_instance['cat'] );
+		$instance['limit']     = strip_tags( $new_instance['limit'] );
+		$instance['show_more'] = strip_tags( $new_instance['show_more'] );
+		$instance['more']      = strip_tags( $new_instance['more'] );
 
-        return $instance;
-    }
+		return $instance;
+	}
 
-    public function form($instance) {
-        if ( $instance ) {
-            $title = esc_attr($instance['title']);
-            $cat = esc_attr($instance['cat']);
-            $limit = esc_attr($instance['limit']);
-            $show_more = esc_attr($instance['show_more']);
-            $more = esc_attr($instance['more']);
-        } else {
-            $title = '';
-            $cat = '';
-            $limit = 5;
-            $show_more = 0;
-            $more = ' Ver mais...';
-        }
+	public function form( $instance ) {
+		if ( $instance ) {
+			$title     = esc_attr( $instance['title'] );
+			$cat       = esc_attr( $instance['cat'] );
+			$limit     = esc_attr( $instance['limit'] );
+			$show_more = esc_attr( $instance['show_more'] );
+			$more      = esc_attr( $instance['more'] );
+		} else {
+			$title     = '';
+			$cat       = '';
+			$limit     = 5;
+			$show_more = 0;
+			$more      = ' Ver mais...';
+		}
 
-        $form = '
+		$form
+			= '
         <p>
-            <label for="' . $this->get_field_id('title') . '">
+            <label for="' . $this->get_field_id( 'title' ) . '">
                 Título
-                <input class="widefat" id="' . $this->get_field_id('title') . '" name="' . $this->get_field_name('title') . '" type="text" value="' . $title . '" />
+                <input class="widefat" id="' . $this->get_field_id( 'title' ) . '" name="'
+			  . $this->get_field_name( 'title' ) . '" type="text" value="' . $title . '" />
             </label>
         </p>
         <p>
-            <label for="' . $this->get_field_id('cat') . '">
+            <label for="' . $this->get_field_id( 'cat' ) . '">
                 Categoria
-                <select id="' . $this->get_field_id('cat') . '" name="' . $this->get_field_name('cat') . '" class="widefat" style="width:100%;">';
+                <select id="' . $this->get_field_id( 'cat' ) . '" name="' . $this->get_field_name( 'cat' )
+			  . '" class="widefat" style="width:100%;">';
 
-        foreach(get_terms('category','parent=0&hide_empty=0') as $term) {
-            $form .= '<option ' . selected($cat, $term->term_id, false ) . ' value="' . $term->term_id . '">' . $term->name . '</option>';
-        }
+		foreach ( get_terms( 'category', 'parent=0&hide_empty=0' ) as $term ) {
+			$form
+				.=
+				'<option ' . selected( $cat, $term->term_id, false ) . ' value="' . $term->term_id . '">' . $term->name
+				. '</option>';
+		}
 
-        $form .= '
+		$form
+			.= '
                 </select>
             </label>
         </p>
         <p>
-            <label for="' . $this->get_field_id('limit') . '">
+            <label for="' . $this->get_field_id( 'limit' ) . '">
                 Quantidade
-                <input class="widefat" id="' . $this->get_field_id('limit') . '" name="' . $this->get_field_name('limit') . '" type="text" value="' . $limit . '" />
+                <input class="widefat" id="' . $this->get_field_id( 'limit' ) . '" name="'
+			   . $this->get_field_name( 'limit' ) . '" type="text" value="' . $limit . '" />
             </label>
         </p>
         <p>
-            <label for="' . $this->get_field_id('show_more') . '">
-                <input type="checkbox" ' . checked($show_more, 1, false ) . ' class="widefat" id="' . $this->get_field_id('show_more') . '" name="' . $this->get_field_name('show_more') . '" type="text" value="1" />Mostrar link para mais?
+            <label for="' . $this->get_field_id( 'show_more' ) . '">
+                <input type="checkbox" ' . checked( $show_more, 1, false ) . ' class="widefat" id="'
+			   . $this->get_field_id( 'show_more' ) . '" name="' . $this->get_field_name( 'show_more' ) . '" type="text" value="1" />Mostrar link para mais?
             </label>
         </p>
         <p>
-            <label for="' . $this->get_field_id('more') . '">
+            <label for="' . $this->get_field_id( 'more' ) . '">
                 Texto link "Ver mais..."
-                <input class="widefat" id="' . $this->get_field_id('more') . '" name="' . $this->get_field_name('more') . '" type="text" value="' . $more . '" />
+                <input class="widefat" id="' . $this->get_field_id( 'more' ) . '" name="'
+			   . $this->get_field_name( 'more' ) . '" type="text" value="' . $more . '" />
             </label>
         </p>
         ';
 
-        echo $form;
-    }
+		echo $form;
+	}
 }
 
 class PHPSP_Topo_Widget extends WP_Widget {
 
-    public function PHPSP_Topo_Widget() {
-        parent::WP_Widget('phpsp-topo', 'PHPSP - Topo', 'Aviso no topo + redes sociais');
-    }
+	public function PHPSP_Topo_Widget() {
+		parent::WP_Widget( 'phpsp-topo', 'PHPSP - Topo', 'Aviso no topo + redes sociais' );
+	}
 
-    public function widget ($args, $instance) {
+	public function widget( $args, $instance ) {
 
-        set_query_var('widget_content', $instance['content']);
+		set_query_var( 'widget_content', $instance['content'] );
 
-        echo $args['before_widget'];
+		echo $args['before_widget'];
 
-        get_template_part('widget', 'topo');
+		get_template_part( 'widget', 'topo' );
 
-        echo $args['after_widget'];
-    }
+		echo $args['after_widget'];
+	}
 
-    public function update($new_instance, $old_instance) {
-        $instance = $old_instance;
-        $instance['content'] = strip_tags($new_instance['content'], '<strong></strong><a></a>');
+	public function update( $new_instance, $old_instance ) {
+		$instance            = $old_instance;
+		$instance['content'] = strip_tags( $new_instance['content'], '<strong></strong><a></a>' );
 
-        return $instance;
-    }
+		return $instance;
+	}
 
-    public function form($instance) {
-        if ( $instance ) {
-            $content = esc_attr($instance['content']);
-        } else {
-            $content = '';
-        }
+	public function form( $instance ) {
+		if ( $instance ) {
+			$content = esc_attr( $instance['content'] );
+		} else {
+			$content = '';
+		}
 
-        $form = '
+		$form
+			= '
         <p>
-            <label for="' . $this->get_field_id('content') . '">
+            <label for="' . $this->get_field_id( 'content' ) . '">
                 Chamada
-                <textarea class="widefat" id="' . $this->get_field_id('content') . '" name="' . $this->get_field_name('content') . '">' . $content . '</textarea>
+                <textarea class="widefat" id="' . $this->get_field_id( 'content' ) . '" name="'
+			  . $this->get_field_name( 'content' ) . '">' . $content . '</textarea>
             </label>
         </p>';
 
-        echo $form;
-    }
+		echo $form;
+	}
 }
 
 class PHPSP_Social_Widget extends WP_Widget {
 
-    public function PHPSP_Social_Widget() {
-        parent::WP_Widget('phpsp-social', 'PHPSP - Social', 'Plugin do Facebook + Twitter');
-    }
+	public function PHPSP_Social_Widget() {
+		parent::WP_Widget( 'phpsp-social', 'PHPSP - Social', 'Plugin do Facebook + Twitter' );
+	}
 
-    public function widget ($args, $instance) {
+	public function widget( $args, $instance ) {
 
-        echo $args['before_widget'];
+		echo $args['before_widget'];
 
-        echo '<section class="container social">';
+		echo '<section class="container social">';
 
-        echo <<<FACEBOOK
+		echo <<<FACEBOOK
         <div id="facebook">
             <div id="fb-root"></div>
             <script>(function(d, s, id) {
@@ -253,69 +275,71 @@ class PHPSP_Social_Widget extends WP_Widget {
 FACEBOOK;
 
 
-        echo <<<TWITTER
+		echo <<<TWITTER
         <div id="twitter">
             <a class="twitter-timeline" href="https://twitter.com/phpsp" data-widget-id="617036286898098176">Tweets by @phpsp</a>
             <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+"://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
         </div>
 TWITTER;
 
-        echo "</section>";
+		echo "</section>";
 
-        echo $args['after_widget'];
-    }
+		echo $args['after_widget'];
+	}
 
-    public function update($new_instance, $old_instance) {
-        $instance = $old_instance;
-        $instance['title'] = strip_tags($new_instance['title'], '<strong></strong>');
+	public function update( $new_instance, $old_instance ) {
+		$instance          = $old_instance;
+		$instance['title'] = strip_tags( $new_instance['title'], '<strong></strong>' );
 
-        return $instance;
-    }
+		return $instance;
+	}
 
-    public function form($instance) {
-        if ( $instance ) {
-            $title = esc_attr($instance['title']);
-        } else {
-            $title = '';
-        }
+	public function form( $instance ) {
+		if ( $instance ) {
+			$title = esc_attr( $instance['title'] );
+		} else {
+			$title = '';
+		}
 
-        $form = '
+		$form
+			= '
         <p>
-            <label for="' . $this->get_field_id('title') . '">
+            <label for="' . $this->get_field_id( 'title' ) . '">
                 Título
-                <input class="widefat" id="' . $this->get_field_id('title') . '" name="' . $this->get_field_name('title') . '" type="text" value="' . $title . '" />
+                <input class="widefat" id="' . $this->get_field_id( 'title' ) . '" name="'
+			  . $this->get_field_name( 'title' ) . '" type="text" value="' . $title . '" />
             </label>
         </p>';
 
-        echo $form;
-    }
+		echo $form;
+	}
 }
 
 class PHPSP_Parceiros_Widget extends WP_Widget {
 
-    public function PHPSP_Parceiros_Widget() {
-        parent::WP_Widget('phpsp-parceiros', 'PHPSP - Parceiros', 'Imagem dos parceiros do PHPSP');
-    }
+	public function PHPSP_Parceiros_Widget() {
+		parent::WP_Widget( 'phpsp-parceiros', 'PHPSP - Parceiros', 'Imagem dos parceiros do PHPSP' );
+	}
 
-    public function widget ($args, $instance) {
-        get_template_part('widget', 'parceiros');
-    }
+	public function widget( $args, $instance ) {
+		get_template_part( 'widget', 'parceiros' );
+	}
 
-    public function update($new_instance, $old_instance) {
-        return $new_instance;
-    }
+	public function update( $new_instance, $old_instance ) {
+		return $new_instance;
+	}
 
-    public function form($instance) {
-        echo '';
-    }
+	public function form( $instance ) {
+		echo '';
+	}
 }
 
 function PHPSP_register_widgets() {
-    register_widget( 'PHPSP_Artigos_Widget' );
-    register_widget( 'PHPSP_Avisos_Widget' );
-    register_widget( 'PHPSP_Topo_Widget' );
-    register_widget( 'PHPSP_Social_Widget' );
-    register_widget( 'PHPSP_Parceiros_Widget' );
+	register_widget( 'PHPSP_Artigos_Widget' );
+	register_widget( 'PHPSP_Avisos_Widget' );
+	register_widget( 'PHPSP_Topo_Widget' );
+	register_widget( 'PHPSP_Social_Widget' );
+	register_widget( 'PHPSP_Parceiros_Widget' );
 }
 
 add_action( 'widgets_init', 'PHPSP_register_widgets' );
@@ -326,143 +350,141 @@ $active_widgets = get_option( 'sidebars_widgets' );
 //Pra nao salvar atoa
 $hasChange = false;
 
-$dataVersion = get_option('phpsp_data_version');
+$dataVersion = get_option( 'phpsp_data_version' );
 
-$forceUdate = version_compare(PHPSP_TEMPLATE_VERSION, $dataVersion, '>') ? true : false;
+$forceUdate = version_compare( PHPSP_TEMPLATE_VERSION, $dataVersion, '>' ) ? true : false;
 
-if($forceUdate)
-{
-    $hasChange = true;
-    $active_widgets = array('array_version' => 1);
-    $active_widgets['orphaned_widgets_1'] = array();
-    $active_widgets['wp_inactive_widgets'] = array();
+if ( $forceUdate ) {
+	$hasChange                             = true;
+	$active_widgets                        = array( 'array_version' => 1 );
+	$active_widgets['orphaned_widgets_1']  = array();
+	$active_widgets['wp_inactive_widgets'] = array();
 }
 
 //Configura a primeira coluna, se estiver vazia
-if (empty($active_widgets['home-column-1'])) {
+if ( empty( $active_widgets['home-column-1'] ) ) {
 
-    $hasChange = true;
+	$hasChange = true;
 
-    //Meetup list
-    $active_widgets['home-column-1'][0] = 'vsmeetgroupslistwidget-1';
+	//Meetup list
+	$active_widgets['home-column-1'][0] = 'vsmeetgroupslistwidget-1';
 
-    $meetup_widget_content_1[1] = array(
-        'title' => 'Próximos Eventos',
-        'ids' => 'php-sp,vagrant-sao-paulo,laravel-sp,wpsampa',
-        'limit' => 7,
-        'highlight_first' => 1,
-        'date_format' => 'd/m @ H:i'
-    );
+	$meetup_widget_content_1[1] = array(
+		'title'           => 'Próximos Eventos',
+		'ids'             => 'php-sp,vagrant-sao-paulo,laravel-sp,wpsampa',
+		'limit'           => 7,
+		'highlight_first' => 1,
+		'date_format'     => 'd/m @ H:i'
+	);
 
-    update_option('widget_vsmeetgroupslistwidget', $meetup_widget_content_1);
+	update_option( 'widget_vsmeetgroupslistwidget', $meetup_widget_content_1 );
 }
 
 //Configura a segunda coluna, se estiver vazia
-if (empty($active_widgets['home-column-2'])) {
+if ( empty( $active_widgets['home-column-2'] ) ) {
 
-    $hasChange = true;
+	$hasChange = true;
 
-    //Artigos
-    $active_widgets['home-column-2'][0] = 'phpsp-artigos-1';
+	//Artigos
+	$active_widgets['home-column-2'][0] = 'phpsp-artigos-1';
 
-    $artigos_widget_content[1] = array(
-        'title' => '<strong>Artigos</strong> da comunidade',
-        'cat' => 3,
-        'limit' => 5,
-        'more' => 'Ver mais artigos...'
-    );
+	$artigos_widget_content[1] = array(
+		'title' => '<strong>Artigos</strong> da comunidade',
+		'cat'   => 3,
+		'limit' => 5,
+		'more'  => 'Ver mais artigos...'
+	);
 
-    update_option('widget_phpsp-artigos', $artigos_widget_content);
+	update_option( 'widget_phpsp-artigos', $artigos_widget_content );
 }
 
 //Configura a terceira coluna, se estiver vazia
-if (empty($active_widgets['home-column-3'])) {
+if ( empty( $active_widgets['home-column-3'] ) ) {
 
-    $hasChange = true;
+	$hasChange = true;
 
-    //Avisos
-    $active_widgets['home-column-3'][0] = 'phpsp-avisos-1';
+	//Avisos
+	$active_widgets['home-column-3'][0] = 'phpsp-avisos-1';
 
-    $avisos_widget_content[1] = array(
-        'title' => '<strong>Avisos</strong> da comunidade',
-        'cat' => 776,
-        'limit' => 1,
-        'show_more' => 0,
-        'more' => 'Ver mais avisos...'
-    );
+	$avisos_widget_content[1] = array(
+		'title'     => '<strong>Avisos</strong> da comunidade',
+		'cat'       => 776,
+		'limit'     => 1,
+		'show_more' => 0,
+		'more'      => 'Ver mais avisos...'
+	);
 
-    update_option('widget_phpsp-avisos', $avisos_widget_content);
+	update_option( 'widget_phpsp-avisos', $avisos_widget_content );
 }
 
 //Configura o topo de avisos
-if (empty($active_widgets['head-announce'])) {
+if ( empty( $active_widgets['head-announce'] ) ) {
 
-    $hasChange = true;
+	$hasChange = true;
 
-    //Topo
-    $active_widgets['head-announce'][0] = 'phpsp-topo-1';
+	//Topo
+	$active_widgets['head-announce'][0] = 'phpsp-topo-1';
 
-    $topo_widget_content[1] = array(
-        'content' => '<strong>Próximos encontros e eventos? </strong>
+	$topo_widget_content[1] = array(
+		'content' => '<strong>Próximos encontros e eventos? </strong>
         <a href="http://www.meetup.com/php-sp/">Visite a página do PHPSP no Meetup</a>',
-    );
+	);
 
-    update_option('widget_phpsp-topo', $topo_widget_content);
+	update_option( 'widget_phpsp-topo', $topo_widget_content );
 }
 
 //Configura o Rodape
-if (empty($active_widgets['footer-links'])) {
+if ( empty( $active_widgets['footer-links'] ) ) {
 
-    $hasChange = true;
+	$hasChange = true;
 
-    //Facebook + Twitter
-    $active_widgets['footer-links'][0] = 'phpsp-social-1';
+	//Facebook + Twitter
+	$active_widgets['footer-links'][0] = 'phpsp-social-1';
 
-    $footer_social_widget_content[1] = array(
-        'title' => 'PHPSP nas redes sociais',
-    );
+	$footer_social_widget_content[1] = array(
+		'title' => 'PHPSP nas redes sociais',
+	);
 
-    $active_widgets['footer-links'][1] = 'phpsp-parceiros-1';
+	$active_widgets['footer-links'][1] = 'phpsp-parceiros-1';
 
-    $footer_partners_widget_content[1] = array();
+	$footer_partners_widget_content[1] = array();
 
-    update_option('widget_phpsp-social', $footer_social_widget_content);
-    update_option('widget_phpsp-parceiros', $footer_partners_widget_content);
+	update_option( 'widget_phpsp-social', $footer_social_widget_content );
+	update_option( 'widget_phpsp-parceiros', $footer_partners_widget_content );
 }
 
 //Configura a lateral direita (paginas internas)
-if (empty($active_widgets['content-right-column-1'])) {
+if ( empty( $active_widgets['content-right-column-1'] ) ) {
 
-    $hasChange = true;
+	$hasChange = true;
 
-    //Outros artigos
-    $active_widgets['content-right-column-1'][0] = 'phpsp-artigos-2';
+	//Outros artigos
+	$active_widgets['content-right-column-1'][0] = 'phpsp-artigos-2';
 
-    $artigos_widget_content[2] = array(
-        'title' => 'Últimos Artigos',
-        'cat' => 3,
-        'limit' => 5,
-        'more' => 'Ver mais artigos...'
-    );
+	$artigos_widget_content[2] = array(
+		'title' => 'Últimos Artigos',
+		'cat'   => 3,
+		'limit' => 5,
+		'more'  => 'Ver mais artigos...'
+	);
 
-    $active_widgets['content-right-column-1'][1] = 'categories-1';
+	$active_widgets['content-right-column-1'][1] = 'categories-1';
 
-    $footer_categories_widget_content[1] = array(
-        'title' => 'Outros Temas',
-        'count' => 1,
-        'hierarchial' => 1,
-    );
+	$footer_categories_widget_content[1] = array(
+		'title'       => 'Outros Temas',
+		'count'       => 1,
+		'hierarchial' => 1,
+	);
 
-    update_option('widget_phpsp-artigos', $artigos_widget_content);
-    update_option('widget_categories', $footer_categories_widget_content);
+	update_option( 'widget_phpsp-artigos', $artigos_widget_content );
+	update_option( 'widget_categories', $footer_categories_widget_content );
 }
 
-if ($hasChange) {
+if ( $hasChange ) {
 
-    update_option( 'sidebars_widgets', $active_widgets );
+	update_option( 'sidebars_widgets', $active_widgets );
 
-    if($forceUdate)
-    {
-        update_option('phpsp_data_version', PHPSP_TEMPLATE_VERSION);
-    }
+	if ( $forceUdate ) {
+		update_option( 'phpsp_data_version', PHPSP_TEMPLATE_VERSION );
+	}
 }


### PR DESCRIPTION
Aprimora a lógica do installer para (tentar) evitar os problemas que tivemos ao subir a 1.4.0;

Criar uma variável (phpsp_data_version) e verifica (usando version_compare()) se a versão do tema é superior ao dos dados (data) que temos instalado. Se for limpar tudo e recria de acordo com o definido nos arquivos de configuração.

Essa branch é baseada no conteúdo do 1.4.0 + as mudanças da branch do rodapé social (#43).

De quebra fiz o PHPStorm aplicar o code style do WordPress nos arquivos de functions e widgets.