### PR TITLE
Exclui RFCs dos resultados de busca para solucionar issue #66

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -713,7 +713,7 @@ function phpsp_busca_menu( $args ) {
 
 function removeRFCFromFeed($query) {
 	$cat = get_category_by_slug('rfc');
-	if ($query->is_feed || $query->is_author) {
+	if ($query->is_feed || $query->is_author || $query->is_search) {
 		$query->set('cat','-'.$cat->term_id);
 	}
 	return $query;


### PR DESCRIPTION
Apesar de acreditar que isso seja um _short term fix_, até que tenhamos alterações no plugin de RFC acredito que seja realmente necessário evitar que RFCs privados tenham seu conteúdo exposto em páginas públicas.